### PR TITLE
Add db and db user creation to deploy role

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,6 +6,7 @@ authors:
   - "Matt Anson"
 dependencies:
   "community.docker": "*"
+  "community.mysql": "*"
 license:
   - "Apache-2.0"
 tags:

--- a/roles/deploy/README.md
+++ b/roles/deploy/README.md
@@ -15,28 +15,35 @@ These configuration options broadly follow those documented by the [Keycloak pro
 * **keycloak_admin_password:** Password for the Keycloak admin user
 * **keycloak_db_password:** Database password
 * **keycloak_db_url_host:** Database host
+* **keycloak_db_login_username:** Database user used to create Keycloak database (if `keycloak_db_ensure_database: true`)
+* **keycloak_db_login_password:** Password for database user used to create Keycloak database (if `keycloak_db_ensure_database: true`)
 
 ##### Optional
-* **keycloak_admin_username:** Admin username for Keycloak (default: "admin")
-* **keycloak_db_type:** Database type (only mariadb tested, default: "mariadb")
-* **keycloak_db_username:** Database username (default: "keycloak")
-* **keycloak_db_url_database:** Database name (default: "keycloak")
-* **keycloak_db_url_port:** Database port (default: 3306)
-* **keycloak_http_bind_interface:** Interface to bind the Keycloak http server (default: "lo")
-* **keycloak_http_port:** Port to bind the keycloak http server (default: "8080")
-* **keycloak_metrics_enabled:** Enable Prometheus metrics (default: false)
-* **keycloak_health_enabled:** Expose Keycloak health check endpoints (default: false)
+* **keycloak_admin_username:** Admin username for Keycloak (default: `"admin"`)
+* **keycloak_db_type:** Database type (only mariadb tested, default: `"mariadb"`)
+* **keycloak_db_ensure_database:** Ensure that the Keycloak database and user exists (default: `true`, requires
+  `keycloak_db_login_username` and `keycloak_db_login_password`)
+* **keycloak_db_mariadb_user_priv:** MySQL privileges string to set when ensuring Keycloak database user (default: `"'{{ keycloak_db_url_database }}.*:ALL'"`)
+* **keycloak_db_mariadb_user_host:** The "host" part of the MySQL username when ensuring Keycloak database user
+  (default: `"%"`, all hosts)
+* **keycloak_db_username:** Database username (default: `"keycloak"`)
+* **keycloak_db_url_database:** Database name (default: `"keycloak"`)
+* **keycloak_db_url_port:** Database port (default: `3306`)
+* **keycloak_http_bind_interface:** Interface to bind the Keycloak http server (default: `"lo"`)
+* **keycloak_http_port:** Port to bind the keycloak http server (default: `"8080"`)
+* **keycloak_metrics_enabled:** Enable Prometheus metrics (default: `false`)
+* **keycloak_health_enabled:** Expose Keycloak health check endpoints (default: `false`)
 * **keycloak_log_level:** Keycloak log level (default: unset - OCI image default)
 * **keycloak_hostname_url:** Keycloak base URL for frontend URLs, including scheme, host, port and path (default: unset - OCI image default)
 * **keycloak_hostname_strict:** Disables dynamically resolving the hostname from request headers (default: unset - OCI image default)
-* **keycloak_hostname_path:** This should be set if proxy uses a different context-path for Keycloak (default unset)
+* **keycloak_hostname_path:** This should be set if proxy uses a different context-path for Keycloak (default: unset - OCI image default)
 * **keycloak_http_relative_path:** Set the path relative to `/` for serving resources (default: unset)
 
 
 #### Keycloak JGroups cache configuration
 ##### Optional
-* **keycloak_jgroups_discovery_protocol:** JGroups cache discovery protocol (only JDBC_PING tested, default: "JDBC_PING")
-* **keycloak_jdbc_driver_name:** JGroups cache JDBC driver name (only org.mariadb.jdbc.Driver tested, default: "org.mariadb.jdbc.Driver")
+* **keycloak_jgroups_discovery_protocol:** JGroups cache discovery protocol (only JDBC_PING tested, default: `"JDBC_PING"`)
+* **keycloak_jdbc_driver_name:** JGroups cache JDBC driver name (only org.mariadb.jdbc.Driver tested, default: `"org.mariadb.jdbc.Driver"`)
 * **keycloak_jdbc_initialise_sql:** JGroups cache initialise SQL statement, default: 
 ```SQL
     CREATE TABLE IF NOT EXISTS JGROUPSPING 
@@ -47,25 +54,25 @@ These configuration options broadly follow those documented by the [Keycloak pro
     PRIMARY KEY (own_addr, cluster_name));
 ```
 * **keycloak_jgroups_discovery_bind_interface:** JGroups discovery bind interface (should be an internal network,
-  default: "lo")
-* **keycloak_jgroups_discovery_bind_port:** JGroups discovery bind port (default: 7800)
-* **keycloak_jgroups_fd_port:** JGroups failure-detection port (default: 57800)
+  default: `"lo"`)
+* **keycloak_jgroups_discovery_bind_port:** JGroups discovery bind port (default: `7800`)
+* **keycloak_jgroups_fd_port:** JGroups failure-detection port (default: `57800`)
 
 #### Keycloak container command
 ##### Optional
-* **keycloak_server_command:** Keycloak server command (default: "start")
-* **keycloak_proxy_type:** Keycloak proxy type (Default: "")
-* **keycloak_server_command_args_extra:** Extra args to pass to the Keycloak server command (default: "")
+* **keycloak_server_command:** Keycloak server command (default: `"start"`)
+* **keycloak_proxy_type:** Keycloak proxy type (Default: `""`)
+* **keycloak_server_command_args_extra:** Extra args to pass to the Keycloak server command (default: `""`)
 
 #### Cache configuration files
 ##### Optional
-* **keycloak_host_config_dir:** Host configuration directory (default: "/etc/keycloak")
-* **keycloak_cache_config_file:** Cache configuration filename (default: "cache-ispn-config.xml")
-* **keycloak_cache_config_file_template:** Cache configuration template file (default: "cache-ispn-jdbc-ping.xml.j2")
+* **keycloak_host_config_dir:** Host configuration directory (default: `"/etc/keycloak"`)
+* **keycloak_cache_config_file:** Cache configuration filename (default: `"cache-ispn-config.xml"`)
+* **keycloak_cache_config_file_template:** Cache configuration template file (default: `"cache-ispn-jdbc-ping.xml.j2"`)
 
 #### Docker volumes
 ##### Optional
-* **keycloak_volumes_extra:** A list of extra volumes to be specified (default: [])
+* **keycloak_volumes_extra:** A list of extra volumes to be specified (default: `[]`)
 
 
 Example playbook (used with OpenStack Kayobe)
@@ -73,15 +80,33 @@ Example playbook (used with OpenStack Kayobe)
 ```YAML
 ---
 - name: Run Keycloak Install role
-  hosts: keycloak
-  roles:
-    - role: stackhpc.keycloak.deploy
+  hosts: controllers
+  tasks:
+    - name: Set a fact about the virtualenv on the remote system
+      set_fact:
+        virtualenv: "{{ ansible_python_interpreter | dirname | dirname }}"
+      when:
+        - ansible_python_interpreter is defined
+        - not ansible_python_interpreter.startswith('/bin/')
+        - not ansible_python_interpreter.startswith('/usr/bin/')
+    
+    - name: Ensure Python PyMySQL module is installed
+      pip:
+        name: pymysql
+        extra_args: "{% if pip_upper_constraints_file %}-c {{ pip_upper_constraints_file }}{% endif %}"
+        virtualenv: "{{ virtualenv is defined | ternary(virtualenv, omit) }}"
+      become: "{{ virtualenv is not defined }}"
+    
+    - import_role: 
+        name: stackhpc.keycloak.deploy
       vars:
         keycloak_admin_username: "{{ keycloak_admin_username }}"
         keycloak_admin_password: "{{ keycloak_admin_password }}"
         keycloak_db_url_host: "{{ database_address | put_address_in_context('url') }}"
         keycloak_db_url_database: keycloak
         keycloak_db_password: "{{ keycloak_database_password }}"
+        keycloak_db_login_user: root
+        keycloak_db_login_password: "{{ database_password }}" 
         keycloak_db_user: keycloak
         keycloak_jgroups_discovery_bind_interface: ens3
         keycloak_proxy_type: edge # Behind HAProxy

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -10,12 +10,17 @@ keycloak_docker_image: "quay.io/keycloak/keycloak"
 # Docker tag to use
 keycloak_docker_tag: "21.1"
 
-#### Keycloak configuration
-# Admin username for Keycloak
-keycloak_admin_username: admin
+#### Keycloak database
+# Ensure that a Keycloak database and user are configured
+keycloak_db_ensure_database: true
 
-# Password for the Keycloak admin user
-keycloak_admin_password: "{{ undef('You must set an admin password for Keycloak using keycloak_admin_password') }}"
+# When ensuring Keycloak user, set the following privileges string
+# (https://docs.ansible.com/ansible/latest/collections/community/mysql/mysql_user_module.html#parameter-priv)
+keycloak_db_mariadb_user_priv: "{{ keycloak_db_url_database }}.*:ALL"
+
+# When ensuring Keycloak user, set the following 'host' part of the username
+# Default is all hosts
+keycloak_db_mariadb_user_host: "%"
 
 # Database type (only mariadb tested)
 keycloak_db_type: "mariadb"
@@ -34,6 +39,13 @@ keycloak_db_url_host: "{{ undef('You must set a database host for keycloak using
 
 # Database port
 keycloak_db_url_port: "3306"
+
+#### Keycloak configuration
+# Admin username for Keycloak
+keycloak_admin_username: admin
+
+# Password for the Keycloak admin user
+keycloak_admin_password: "{{ undef('You must set an admin password for Keycloak using keycloak_admin_password') }}"
 
 # Interface to bind the Keycloak http server
 keycloak_http_bind_interface: "lo"

--- a/roles/deploy/tasks/database.yml
+++ b/roles/deploy/tasks/database.yml
@@ -1,0 +1,19 @@
+---
+- name: Ensure Keycloak database exists
+  community.mysql.mysql_db:
+    name: "{{ keycloak_db_url_database }}"
+    login_user: "{{ keycloak_db_login_username }}"
+    login_password: "{{ keycloak_db_login_password }}"
+    login_host: "{{ keycloak_db_url_host }}"
+    login_port: "{{ keycloak_db_url_port }}"
+
+- name: Ensure Keycloak database user exists
+  community.mysql.mysql_user:
+    name: "{{ keycloak_db_username }}"
+    password: "{{ keycloak_db_password }}"
+    priv: "{{ keycloak_db_mariadb_user_priv }}"
+    host: "{{ keycloak_db_mariadb_user_host }}"
+    login_user: "{{ keycloak_db_login_username }}"
+    login_password: "{{ keycloak_db_login_password }}"
+    login_host: "{{ keycloak_db_url_host }}"
+    login_port: "{{ keycloak_db_url_port }}"

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -1,5 +1,13 @@
 ---
+- name: Run prechecks
+  include_tasks: prechecks.yml
 
+- name: Ensure Keycloak database and Keycloak database user
+  include_tasks: database.yml
+  when: 
+   - keycloak_db_ensure_database
+   - inventory_hostname == play_hosts[0]
+    
 - name: Ensure Keycloak host config directory
   file:
     state: directory

--- a/roles/deploy/tasks/prechecks.yml
+++ b/roles/deploy/tasks/prechecks.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Fail if database admin credentials are not provided when ensuring Keycloak database
+  fail:
+    msg: >-
+      Set keycloak_db_login_username and keycloak_db_login_password when
+      keycloak_db_ensure_database is true 
+  when:
+    - keycloak_db_ensure_database
+    - keycloak_db_login_username is not defined or keycloak_db_login_password is not defined


### PR DESCRIPTION
Optionally (but by default) ensure that the database backend is how Keycloak expects it.